### PR TITLE
feat: add cron job to keep server alive and update dependencies

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+# Keep environment variables out of version control
+.env
+
+/src/generated/prisma

--- a/apps/api/src/cron-job.ts
+++ b/apps/api/src/cron-job.ts
@@ -1,0 +1,18 @@
+import cron from 'node-cron';
+
+export function keepServerAlive() {
+    cron.schedule('*/10 * * * *', async () => {
+        try{
+            const response = await fetch('http://localhost:3333/');
+            if(response.ok){
+                console.log('Server is alive');
+            }
+            else{
+                console.error('Server is down');
+            }
+        }
+        catch(error){
+            console.error('Error pinging server:', error);
+        }
+    })
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,6 +3,7 @@ import cors from '@fastify/cors';
 import { env } from './env';
 import { lukas, marcus } from './openai';
 import { sendEmail } from './resend';
+import { keepServerAlive } from './cron-job';
 
 const fastify = Fastify();
 
@@ -10,6 +11,8 @@ fastify.register(cors, {
   origin: env.CORS_URL,
   strictPreflight: false,
 });
+
+keepServerAlive();
 
 fastify.get('/', async (request, reply) => reply.send({
   message: 'Hello from the API!',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,13 @@
         "framer-motion": "^11.18.2",
         "motion": "^12.19.0",
         "next-intl": "^4.3.1",
+        "node-cron": "^4.2.1",
         "react-icons": "^5.5.0",
         "remeda": "^2.21.3",
         "resend": "^4.6.0"
       },
       "devDependencies": {
+        "@types/node-cron": "^3.0.11",
         "prettier": "^3.5.3",
         "turbo": "^2.4.4",
         "typescript": "5.8.2"
@@ -2713,6 +2715,12 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.12",
@@ -8348,6 +8356,14 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-domexception": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "check-types": "turbo run check-types"
   },
   "devDependencies": {
+    "@types/node-cron": "^3.0.11",
     "prettier": "^3.5.3",
     "turbo": "^2.4.4",
     "typescript": "5.8.2"
@@ -28,6 +29,7 @@
     "framer-motion": "^11.18.2",
     "motion": "^12.19.0",
     "next-intl": "^4.3.1",
+    "node-cron": "^4.2.1",
     "react-icons": "^5.5.0",
     "remeda": "^2.21.3",
     "resend": "^4.6.0"


### PR DESCRIPTION
This pull request introduces a scheduled job to keep the API server alive and makes related dependency and configuration updates. The main changes include adding a cron job using `node-cron`, updating the `.gitignore` to exclude environment and generated files, and installing necessary dependencies.

**Server keep-alive functionality:**

* Added a new `keepServerAlive` function in `apps/api/src/cron-job.ts` that pings the server every 10 minutes using `node-cron` to help ensure the server stays responsive.
* Integrated the `keepServerAlive` function into the API server startup in `apps/api/src/server.ts`. [[1]](diffhunk://#diff-3504cff00dc0b301e00da4235ed65736b5fd11064dd71e70f2cca2e4f00f77ebR6) [[2]](diffhunk://#diff-3504cff00dc0b301e00da4235ed65736b5fd11064dd71e70f2cca2e4f00f77ebR15-R16)

**Dependency and configuration updates:**

* Added `node-cron` and its type definitions (`@types/node-cron`) to the project dependencies in `package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R11) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R32)
* Updated `.gitignore` in `apps/api` to exclude `node_modules`, `.env`, and generated Prisma files from version control.